### PR TITLE
Fix class name reference

### DIFF
--- a/config/ifrs.php
+++ b/config/ifrs.php
@@ -13,6 +13,7 @@ use IFRS\Models\ReportingPeriod;
 
 use IFRS\Reports\IncomeStatement;
 use IFRS\Reports\BalanceSheet;
+use IFRS\Reports\TrialBalance;
 
 return [
 
@@ -149,7 +150,7 @@ return [
         BalanceSheet::RECONCILIATION => 'Reconciliation',
 
         // Trial Balance
-        BalanceSheet::TITLE => 'Trial Balance',
+        TrialBalance::TITLE => 'Trial Balance',
     ],
 
     'balances' => [


### PR DESCRIPTION
Fixes the config key for the `TrialBalance` report title.