### PR TITLE
Cleanup and cosmetic fixes.

### DIFF
--- a/src/Exceptions/MissingForexAccount.php
+++ b/src/Exceptions/MissingForexAccount.php
@@ -37,4 +37,3 @@ class MissingForexAccount extends IFRSException
         parent::__construct($error.$message, $code);
     }
 }
-

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -254,7 +254,7 @@ class Account extends Model implements Recyclable, Segragatable
         $balance = 0;
 
         foreach ($this->balances->where("reporting_period_id", $period->id) as $record) {
-            $amount = $record->amount / $record->exchange_rate->rate;
+            $amount = $record->amount / $record->exchangeRate->rate;
             $record->balance_type == Balance::DEBIT ? $balance += $amount : $balance -= $amount;
         }
         return $balance;

--- a/src/Models/Assignment.php
+++ b/src/Models/Assignment.php
@@ -132,8 +132,8 @@ class Assignment extends Model implements Segragatable
         $transactionType = $this->transaction->transaction_type;
         $clearedType = $this->cleared->transaction_type;
 
-        $transactionRate = $this->transaction->exchange_rate->rate;
-        $clearedRate = $this->cleared->exchange_rate->rate;
+        $transactionRate = $this->transaction->exchangeRate->rate;
+        $clearedRate = $this->cleared->exchangeRate->rate;
 
         // Assignable Transactions
         $assignable = [

--- a/src/Models/Balance.php
+++ b/src/Models/Balance.php
@@ -243,7 +243,7 @@ class Balance extends Model implements Recyclable, Clearable, Segragatable
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function exchange_rate()
+    public function exchangeRate()
     {
         return $this->belongsTo(ExchangeRate::class);
     }

--- a/src/Models/ExchangeRate.php
+++ b/src/Models/ExchangeRate.php
@@ -71,7 +71,7 @@ class ExchangeRate extends Model implements Segragatable, Recyclable
      */
     public function currency()
     {
-        return $this->BelongsTo(Currency::class);
+        return $this->belongsTo(Currency::class);
     }
 
     /**

--- a/src/Models/Ledger.php
+++ b/src/Models/Ledger.php
@@ -78,7 +78,7 @@ class Ledger extends Model implements Segragatable
         $post->date = $folio->date = $transaction->transaction_date;
         $post->line_item_id = $folio->line_item_id = $lineItem->id;
         $post->vat_id = $folio->vat_id = $lineItem->vat_id;
-        $post->amount = $folio->amount = $amount * $transaction->exchange_rate->rate;
+        $post->amount = $folio->amount = $amount * $transaction->exchangeRate->rate;
 
         // different double entry data
         $post->post_account = $folio->folio_account = $transaction->account_id;
@@ -115,7 +115,7 @@ class Ledger extends Model implements Segragatable
             $post->date = $folio->date = $transaction->transaction_date;
             $post->line_item_id = $folio->line_item_id = $lineItem->id;
             $post->vat_id = $folio->vat_id = $lineItem->vat_id;
-            $post->amount = $folio->amount = $lineItem->amount * $transaction->exchange_rate->rate;
+            $post->amount = $folio->amount = $lineItem->amount * $transaction->exchangeRate->rate;
 
             // different double entry data
             $post->post_account = $folio->folio_account = $transaction->account_id;
@@ -161,7 +161,7 @@ class Ledger extends Model implements Segragatable
      */
     public function postAccount()
     {
-        return $this->HasOne(Account::class, 'id', 'post_account');
+        return $this->hasOne(Account::class, 'id', 'post_account');
     }
 
     /**
@@ -171,7 +171,7 @@ class Ledger extends Model implements Segragatable
      */
     public function folioAccount()
     {
-        return $this->HasOne(Account::class, 'id', 'folio_account');
+        return $this->hasOne(Account::class, 'id', 'folio_account');
     }
 
     /**
@@ -181,7 +181,7 @@ class Ledger extends Model implements Segragatable
      */
     public function lineItem()
     {
-        return $this->BelongsTo(LineItem::class, 'line_item_id', 'id');
+        return $this->belongsTo(LineItem::class, 'line_item_id', 'id');
     }
 
     /**
@@ -245,7 +245,7 @@ class Ledger extends Model implements Segragatable
         ]);
 
         foreach ($query->get() as $record) {
-            $amount = $record->amount / $record->transaction->exchange_rate->rate;
+            $amount = $record->amount / $record->transaction->exchangeRate->rate;
             $record->entry_type == Balance::DEBIT ? $contribution += $amount : $contribution -= $amount;
         }
         return $contribution;

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -78,7 +78,7 @@ class LineItem extends Model implements Recyclable, Segragatable
      */
     public function ledgers()
     {
-        return $this->HasMany(Ledger::class, 'line_item_id', 'id');
+        return $this->hasMany(Ledger::class, 'line_item_id', 'id');
     }
 
     /**

--- a/src/Models/ReportingPeriod.php
+++ b/src/Models/ReportingPeriod.php
@@ -91,7 +91,7 @@ class ReportingPeriod extends Model implements Segragatable, Recyclable
      * Fetch reporting period for the date
      *
      * @param Carbon $date
-     * @return int
+     * @return self
      */
     public static function getPeriod(Carbon $date = null)
     {

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -66,7 +66,7 @@ class Transaction extends Model implements Segragatable, Recyclable, Clearable, 
     /**
      * Transaction Model Name
      *
-     * @var array
+     * @var string
      */
 
     const MODELNAME = self::class;
@@ -356,7 +356,6 @@ class Transaction extends Model implements Segragatable, Recyclable, Clearable, 
         $amount = 0;
 
         if ($this->is_posted) {
-
             foreach ($this->ledgers->where("entry_type", Balance::DEBIT) as $ledger) {
                 $amount += $ledger->amount / $this->exchange_rate->rate;
             }

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -41,7 +41,7 @@ use IFRS\Exceptions\AdjustingReportingPeriod;
  * @package Ekmungai\Eloquent-IFRS
  *
  * @property Entity $entity
- * @property ExchangeRate $exchange_rate
+ * @property ExchangeRate $exchangeRate
  * @property Account $account
  * @property Currency $currency
  * @property Carbon $transaction_date
@@ -156,7 +156,7 @@ class Transaction extends Model implements Segragatable, Recyclable, Clearable, 
     {
         if (count($this->items)) {
             $lineItem = array_pop($this->items);
-            $this->line_items()->save($lineItem);
+            $this->lineItems()->save($lineItem);
 
             $this->saveLineItems();
         }
@@ -263,9 +263,9 @@ class Transaction extends Model implements Segragatable, Recyclable, Clearable, 
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function line_items()
+    public function lineItems()
     {
-        return $this->HasMany(LineItem::class, 'transaction_id', 'id');
+        return $this->hasMany(LineItem::class, 'transaction_id', 'id');
     }
 
     /**
@@ -275,7 +275,7 @@ class Transaction extends Model implements Segragatable, Recyclable, Clearable, 
      */
     public function ledgers()
     {
-        return $this->HasMany(Ledger::class, 'transaction_id', 'id');
+        return $this->hasMany(Ledger::class, 'transaction_id', 'id');
     }
 
     /**
@@ -303,7 +303,7 @@ class Transaction extends Model implements Segragatable, Recyclable, Clearable, 
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function exchange_rate()
+    public function exchangeRate()
     {
         return $this->belongsTo(ExchangeRate::class);
     }
@@ -315,7 +315,7 @@ class Transaction extends Model implements Segragatable, Recyclable, Clearable, 
      */
     public function assignments()
     {
-        return $this->HasMany(Assignment::class, 'transaction_id', 'id');
+        return $this->hasMany(Assignment::class, 'transaction_id', 'id');
     }
 
     /**
@@ -357,7 +357,7 @@ class Transaction extends Model implements Segragatable, Recyclable, Clearable, 
 
         if ($this->is_posted) {
             foreach ($this->ledgers->where("entry_type", Balance::DEBIT) as $ledger) {
-                $amount += $ledger->amount / $this->exchange_rate->rate;
+                $amount += $ledger->amount / $this->exchangeRate->rate;
             }
         } else {
             foreach ($this->getLineItems() as $lineItem) {
@@ -385,7 +385,7 @@ class Transaction extends Model implements Segragatable, Recyclable, Clearable, 
      */
     public function getLineItems()
     {
-        foreach ($this->line_items as $lineItem) {
+        foreach ($this->lineItems as $lineItem) {
             $this->addLineItem($lineItem);
         }
         return $this->items;
@@ -432,7 +432,7 @@ class Transaction extends Model implements Segragatable, Recyclable, Clearable, 
         $lineItem->save();
 
         // reload items to reflect changes
-        $this->load('line_items');
+        $this->load('lineItems');
     }
 
     /**
@@ -459,7 +459,7 @@ class Transaction extends Model implements Segragatable, Recyclable, Clearable, 
         $this->saveLineItems();
 
         // reload items to reflect changes
-        $this->load('line_items');
+        $this->load('lineItems');
 
         return $save;
     }

--- a/src/Models/Vat.php
+++ b/src/Models/Vat.php
@@ -85,7 +85,7 @@ class Vat extends Model implements Segragatable, Recyclable
      */
     public function account()
     {
-        return $this->HasOne(Account::class, 'id', 'account_id');
+        return $this->hasOne(Account::class, 'id', 'account_id');
     }
 
     /**

--- a/src/Reports/AccountSchedule.php
+++ b/src/Reports/AccountSchedule.php
@@ -44,7 +44,7 @@ class AccountSchedule extends AccountStatement
     {
         $clearedAmount = $originalAmount = 0;
 
-        $originalAmount = $transaction->amount / $transaction->exchange_rate->rate;
+        $originalAmount = $transaction->amount / $transaction->exchangeRate->rate;
         $clearedAmount = $transaction->cleared_amount;
         $unclearedAmount = $originalAmount - $clearedAmount;
 
@@ -112,8 +112,7 @@ class AccountSchedule extends AccountStatement
         foreach ($transactions->get() as $transaction) {
             $transaction = Transaction::find($transaction->id);
 
-            if (
-                $transaction->transaction_type == Transaction::JN
+            if ($transaction->transaction_type == Transaction::JN
                 && (($this->account->account_type == Account::RECEIVABLE && $transaction->is_credited)
                     || ($this->account->account_type == Account::PAYABLE && !$transaction->is_credited))
             ) {

--- a/src/Reports/AgingSchedule.php
+++ b/src/Reports/AgingSchedule.php
@@ -94,7 +94,6 @@ class AgingSchedule
         $balances = array_fill_keys(array_keys($this->brackets), 0);
 
         foreach (Account::where("account_type", $accountType)->get() as $account) {
-
             $account_balances = array_fill_keys(array_keys($this->brackets), 0);
 
             $schedule = new AccountSchedule($account->id, $currencyId, $endDate);
@@ -102,7 +101,6 @@ class AgingSchedule
 
             foreach ($schedule->transactions as $transaction) {
                 if ($transaction->unclearedAmount > 0) {
-
                     $bound = $this->getBracket($transaction->age, $this->brackets);
 
                     $balances[$bound] += $transaction->unclearedAmount;

--- a/src/Traits/Assigning.php
+++ b/src/Traits/Assigning.php
@@ -21,6 +21,6 @@ trait Assigning
         foreach ($this->assignments as $assignment) {
             $balance += $assignment->amount;
         }
-        return $this->amount / $this->exchange_rate->rate - $balance;
+        return $this->amount / $this->exchangeRate->rate - $balance;
     }
 }

--- a/tests/Unit/AccountBalanceTest.php
+++ b/tests/Unit/AccountBalanceTest.php
@@ -40,11 +40,11 @@ class AccountBalanceTest extends TestCase
             ]
         );
 
-        $exchange_rate = factory(ExchangeRate::class)->create();
+        $exchangeRate = factory(ExchangeRate::class)->create();
 
         $balance = new Balance(
             [
-                'exchange_rate_id' => $exchange_rate->id,
+                'exchange_rate_id' => $exchangeRate->id,
                 'currency_id' => $currency->id,
                 'account_id' => $account->id,
                 'transaction_type' => Transaction::JN,
@@ -58,7 +58,7 @@ class AccountBalanceTest extends TestCase
 
         $this->assertEquals($balance->currency->name, $currency->name);
         $this->assertEquals($balance->account->name, $account->name);
-        $this->assertEquals($balance->exchange_rate->rate, $exchange_rate->rate);
+        $this->assertEquals($balance->exchangeRate->rate, $exchangeRate->rate);
         $this->assertEquals($balance->reportingPeriod->calendar_year, date("Y"));
         $this->assertEquals($balance->transaction_no, $account->id . 'KES' . date("Y"));
         $this->assertEquals(

--- a/tests/Unit/TransactionTest.php
+++ b/tests/Unit/TransactionTest.php
@@ -36,7 +36,7 @@ class TransactionTest extends TestCase
     {
         $currency = factory(Currency::class)->create();
         $account = factory(Account::class)->create();
-        $exchange_rate = factory(ExchangeRate::class)->create([
+        $exchangeRate = factory(ExchangeRate::class)->create([
             "rate" => 1
         ]);
 
@@ -77,7 +77,7 @@ class TransactionTest extends TestCase
 
         $this->assertEquals($transaction->currency->name, $currency->name);
         $this->assertEquals($transaction->account->name, $account->name);
-        $this->assertEquals($transaction->exchange_rate->rate, $exchange_rate->rate);
+        $this->assertEquals($transaction->exchangeRate->rate, $exchangeRate->rate);
         $this->assertEquals($transaction->ledgers()->get()[0]->post_account, $account->id);
         $this->assertEquals(count($transaction->assignments), 5);
         $this->assertEquals(


### PR DESCRIPTION
Use camelCase conventions:
```php
// before
$this->BelongsTo(Currency::class)
$record->exchange_rate->rate

// after
$this->belongsTo(Currency::class)
$record->exchangeRate->rate
```

And also some return types mismatches and one test file name did not match the class name.

