### PR TITLE
Fix spelling and examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Open your `User` model and implement the below interfaces and also include the t
 
 use IFRS\Traits\IFRSUser;
 use IFRS\Interfaces\Recyclable;
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 ...
 
 class User ... implements Recyclable, Segregatable {

--- a/README.md
+++ b/README.md
@@ -14,15 +14,21 @@ The package supports multiple Entities (Companies), Account Categorization, Tran
 
 The motivation for this package can be found in detail on my blog post [here](https://karanjamungai.com/posts/accounting_software/)
 ## Table of contents
-1. [Installation](#installation)
-2. [Configuration](#configuration)
-3. [Usage](#usage)
-4. [Changelog](#changelog)
-5. [Getting involved](#getting-involved)
-6. [Contributing](#contributing)
-7. [Roadmap](#roadmap)
-8. [License](#license)
-9. [References](#references)
+- [Eloquent IFRS](#eloquent-ifrs)
+  - [Table of contents](#table-of-contents)
+  - [Installation](#installation)
+      - [For production](#for-production)
+      - [For development](#for-development)
+  - [Configuration](#configuration)
+  - [Usage](#usage)
+    - [DB Collision](#db-collision)
+    - [Examples](#examples)
+  - [Changelog](#changelog)
+  - [Getting Involved](#getting-involved)
+  - [Contributing](#contributing)
+  - [Roadmap](#roadmap)
+  - [License](#license)
+  - [References](#references)
 
 ## Installation
 
@@ -91,6 +97,7 @@ class User ... implements Recyclable, Segregatable {
 ?>
 ```
 
+### Examples
 This simple example covers the four scenarios to demonstrate the use of the package. First, a description of a Cash Sale to a customer, then a Credit Sale (Invoice) to a client, then a Cash Purchase for an operations expense and finally a Credit Purchase (Bill) from a Supplier for a non operations purpose (Asset Purchase).
 
 First we'll setup the Company (Reporting Entity) and required Accounts to record the Transactions. (Assuming that a registered User already exists):
@@ -100,15 +107,15 @@ use IFRS\Models\Entity;
 use IFRS\Models\Currency;
 
 //Entities require a reporting currency
-$currency = new Currency([
+$currency = Currency::create([
     "name" => "Euro",
     "currency_code" => "EUR"
-)->save();
+]);
 
-$entity = new Entity([
+$entity = Entity::create([
     "name" => "Example Company",
     "currency_id" => $currency->id
-])->save();
+]);
 
 ```
 We also need the VAT Rates that apply to the Entity:
@@ -116,23 +123,23 @@ We also need the VAT Rates that apply to the Entity:
 ```php
 use IFRS\Models\Vat;
 
-$outputVat = new Vat([
+$outputVat = Vat::create([
     'name' => "Standard Output Vat",
     'code' => "O",
     'rate' => 20,
-])->save();
+]);
 
-$outputVat = new Vat([
+$inputVat = Vat::create([
     'name' => "Standard Input Vat",
     'code' => "I",
     'rate' => 10,
-])->save();
+]);
 
-$outputVat = new Vat([
+$zeroVat = Vat::create([
     'name' => "Zero Vat",
     'code' => "Z",
     'rate' => 0,
-])->save();
+]);
 ```
 
 Now we'll set up some Accounts:
@@ -140,45 +147,45 @@ Now we'll set up some Accounts:
 ```php
 use IFRS\Models\Account;
 
-$bankAccount = new Account([
+$bankAccount = Account::create([
     'name' => "Sales Account",
     'account_type' => Account::BANK,
-])->save();
+]);
 
-$revenueAccount = new Account([
+$revenueAccount = Account::create([
     'name' => "Bank Account",
     'account_type' => Account::OPERATING_REVENUE,
-])->save();
+]);
 
-$clientAccount = new Account([
+$clientAccount = Account::create([
     'name' => "Example Client Account",
     'account_type' => Account::RECEIVABLE,
-])->save();
+]);
 
-$supplierAccount = new Account([
+$supplierAccount = Account::create([
     'name' => "Example Supplier Account",
     'account_type' => Account::PAYABLE,
-])->save();
+]);
 
-$opexAccount = new Account([
+$opexAccount = Account::create([
     'name' => "Operations Expense Account",
     'account_type' => Account::OPERATING_EXPENSE,
-])->save();
+]);
 
-$assetAccount = new Account([
+$assetAccount = Account::create([
     'name' => "Office Equipment Account",
     'account_type' => Account::NON_CURRENT_ASSET,
-])->save();
+]);
 
-$salesVatAccount = new Account([
+$salesVatAccount = Account::create([
     'name' => "Sales VAT Account",
     'account_type' => Account::CONTROL_ACCOUNT,
-])->save();
+]);
 
-$purchasesVatAccount = new Account([
+$purchasesVatAccount = Account::create([
     'name' => "Input VAT Account",
     'account_type' => Account::CONTROL_ACCOUNT,
-])->save();
+]);
 ```
 
 Now that all Accounts are prepared, we can create the first Transaction, a Cash Sale:
@@ -186,25 +193,25 @@ Now that all Accounts are prepared, we can create the first Transaction, a Cash 
 ```php
 use IFRS\Transactions\CashSale;
 
-$cashSale = new CashSale([
+$cashSale = CashSale::create([
     'account_id' => $bankAccount->id,
     'date' => Carbon::now(),
     'narration' => "Example Cash Sale",
-])->save(); // Intermediate save does not record the transaction in the Ledger
+]); // Intermediate save does not record the transaction in the Ledger
 ```
 So far the Transaction has only one side of the double entry, so we create a Line Item for the other side:
 
 ```php
 use IFRS\models\LineItem;
 
-$cashSaleLineItem = new LineItem([
+$cashSaleLineItem = LineItem::create([
     'vat_id' => $outputVat->id,
     'account_id' => $revenueAccount->id,
     'vat_account_id' => $salesVatAccount->id,
     'description' => "Example Cash Sale Line Item",
     'quantity' => 1,
     'amount' => 100,
-])->save();
+]);
 
 $cashSale->addLineItem($cashSaleLineItem);
 $cashSale->post(); // This posts the Transaction to the Ledger
@@ -215,20 +222,20 @@ The rest of the transactions:
 ```php
 use IFRS\Transactions\ClientInvoice;
 
-$clientInvoice = new ClientInvoice([
+$clientInvoice = ClientInvoice::create([
     'account_id' => $clientAccount->id,
     'date' => Carbon::now(),
     'narration' => "Example Credit Sale",
-])->save();
+]);
 
-$clientInvoiceLineItem = new LineItem([
+$clientInvoiceLineItem = LineItem::create([
     'vat_id' => $outputVat->id,
     'account_id' => $revenueAccount->id,
     'vat_account_id' => $salesVatAccount->id,
     'description' => "Example Credit Sale Line Item",
     'quantity' => 2,
     'amount' => 50,
-])->save();
+]);
 
 $clientInvoice->addLineItem($clientInvoiceLineItem);
 
@@ -237,58 +244,58 @@ $clientInvoice->post();
 
 use IFRS\Transactions\CashPurchase;
 
-$cashPurchase = new CashPurchase([
+$cashPurchase = CashPurchase::create([
     'account_id' => $clientAccount->id,
     'date' => Carbon::now(),
     'narration' => "Example Cash Purchase",
-])->save();
+]);
 
-$cashPurchaseLineItem = new LineItem([
+$cashPurchaseLineItem = LineItem::create([
     'vat_id' => $inputVat->id,
     'account_id' => $opexAccount->id,
     'vat_account_id' => $purchaseVatAccount->id,
     'description' => "Example Cash Purchase Line Item",
     'quantity' => 4,
     'amount' => 25,
-])->save();
+]);
 
 $cashPurchase->addLineItem($cashPurchaseLineItem)->post();
 
 use IFRS\Transactions\SupplierBill;
 
-$supplierBill = new SupplierBill([
+$supplierBill = SupplierBill::create([
     'account_id' => $supplierAccount->id,
     'date' => Carbon::now(),
     'narration' => "Example Credit Purchase",
-])->save();
+]);
 
-$supplierBillLineItem = new LineItem([
+$supplierBillLineItem = LineItem::create([
     'vat_id' => $inputVat->id,
     'account_id' => $assetAccount->id,
     'vat_account_id' => $purchaseVatAccount->id,
     'description' => "Example Credit Purchase Line Item",
     'quantity' => 4,
     'amount' => 25,
-])->save();
+]);
 
 $supplierBill->addLineItem($supplierBillLineItem)->post();
 
 use IFRS\Transactions\ClientReceipt;
 
-$clientReceipt = new ClientReceipt([
+$clientReceipt = ClientReceipt::create([
     'account_id' => $clientAccount->id,
     'date' => Carbon::now(),
     'narration' => "Example Client Payment",
-])->save();
+]);
 
-$clientReceiptLineItem = new LineItem([
+$clientReceiptLineItem = LineItem::create([
     'vat_id' => $zeroVat->id,
     'account_id' => $bankAccount->id,
     'vat_account_id' => $purchaseVatAccount->id,
     'description' => "Part payment for Client Invoice",
     'quantity' => 1,
     'amount' => 50,
-])->save();
+]);
 
 $clientReceipt->addLineItem($clientReceiptLineItem)->post();
 ```
@@ -300,12 +307,12 @@ use IFRS\Models\Assignment;
 echo $clientInvoice->clearedAmount(); //0: Currently the Invoice has not been cleared at all
 echo $clientReceipt->balance(); //50: The Receipt has not been assigned to clear any transaction
 
-$assignment = new Assignment([
+$assignment = Assignment::create([
     'transaction_id' => $clientReceipt->id,
     'cleared_id' => $clientInvoice->id,
     'cleared_type'=> $clientInvoice->getClearedType(),
     'amount' => 50,
-])->save();
+]);
 
 echo $clientInvoice->clearedAmount(); //50
 echo $clientReceipt->balance(); //0: The Receipt has been assigned fully to the Invoice
@@ -316,10 +323,10 @@ We have now some Transactions in the Ledger, so lets generate some reports. Firs
 ```php
 use IFRS\Models\ReportingPeriod;
 
-$period = new ReportingPeriod([
+$period = ReportingPeriod::create([
     'period_count' => 1,
     'year' => 2020,
-])->save();
+]);
 
 ```
 The Income Statement (Profit and Loss):

--- a/src/Interfaces/Segregatable.php
+++ b/src/Interfaces/Segregatable.php
@@ -14,14 +14,14 @@ namespace IFRS\Interfaces;
  *
  * @author emung
  */
-interface Segragatable
+interface Segregatable
 {
     /**
      * Register EntityScope for Model.
      *
      * @return null
      */
-    public static function bootSegragating();
+    public static function bootSegregating();
 
     /**
      * Model's Parent Entity.

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -16,9 +16,9 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 
 use IFRS\Interfaces\Recyclable;
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 
-use IFRS\Traits\Segragating;
+use IFRS\Traits\Segregating;
 use IFRS\Traits\Recycling;
 use IFRS\Traits\ModelTablePrefix;
 
@@ -44,9 +44,9 @@ use Carbon\Carbon;
  * @property float $currentBalance
  * @property float $closingBalance
  */
-class Account extends Model implements Recyclable, Segragatable
+class Account extends Model implements Recyclable, Segregatable
 {
-    use Segragating;
+    use Segregating;
     use SoftDeletes;
     use Recycling;
     use ModelTablePrefix;

--- a/src/Models/Assignment.php
+++ b/src/Models/Assignment.php
@@ -24,12 +24,12 @@ use IFRS\Exceptions\UnclearableTransaction;
 use IFRS\Exceptions\UnpostedAssignment;
 
 use IFRS\Interfaces\Assignable;
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 
 use IFRS\Reports\AccountSchedule;
 
 use IFRS\Traits\ModelTablePrefix;
-use IFRS\Traits\Segragating;
+use IFRS\Traits\Segregating;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -46,9 +46,9 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property Carbon $destroyed_at
  * @property Carbon $deleted_at
  */
-class Assignment extends Model implements Segragatable
+class Assignment extends Model implements Segregatable
 {
-    use Segragating;
+    use Segregating;
     use SoftDeletes;
     use ModelTablePrefix;
 

--- a/src/Models/Balance.php
+++ b/src/Models/Balance.php
@@ -18,10 +18,10 @@ use IFRS\Reports\IncomeStatement;
 
 use IFRS\Interfaces\Recyclable;
 use IFRS\Interfaces\Clearable;
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 
 use IFRS\Traits\Recycling;
-use IFRS\Traits\Segragating;
+use IFRS\Traits\Segregating;
 use IFRS\Traits\Clearing;
 use IFRS\Traits\ModelTablePrefix;
 
@@ -49,9 +49,9 @@ use IFRS\Exceptions\InvalidBalanceDate;
  * @property Carbon $destroyed_at
  * @property Carbon $deleted_at
  */
-class Balance extends Model implements Recyclable, Clearable, Segragatable
+class Balance extends Model implements Recyclable, Clearable, Segregatable
 {
-    use Segragating;
+    use Segregating;
     use SoftDeletes;
     use Recycling;
     use Clearing;

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -13,10 +13,10 @@ namespace IFRS\Models;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Model;
 
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 use IFRS\Interfaces\Recyclable;
 
-use IFRS\Traits\Segragating;
+use IFRS\Traits\Segregating;
 use IFRS\Traits\Recycling;
 use IFRS\Traits\ModelTablePrefix;
 
@@ -31,9 +31,9 @@ use IFRS\Traits\ModelTablePrefix;
  * @property Carbon $destroyed_at
  * @property Carbon $deleted_at
  */
-class Category extends Model implements Segragatable, Recyclable
+class Category extends Model implements Segregatable, Recyclable
 {
-    use Segragating;
+    use Segregating;
     use SoftDeletes;
     use Recycling;
     use ModelTablePrefix;

--- a/src/Models/ExchangeRate.php
+++ b/src/Models/ExchangeRate.php
@@ -13,10 +13,10 @@ namespace IFRS\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 use IFRS\Interfaces\Recyclable;
 
-use IFRS\Traits\Segragating;
+use IFRS\Traits\Segregating;
 use IFRS\Traits\Recycling;
 use IFRS\Traits\ModelTablePrefix;
 
@@ -33,9 +33,9 @@ use IFRS\Traits\ModelTablePrefix;
  * @property Carbon $destroyed_at
  * @property Carbon $deleted_at
  */
-class ExchangeRate extends Model implements Segragatable, Recyclable
+class ExchangeRate extends Model implements Segregatable, Recyclable
 {
-    use Segragating;
+    use Segregating;
     use SoftDeletes;
     use Recycling;
     use ModelTablePrefix;

--- a/src/Models/Ledger.php
+++ b/src/Models/Ledger.php
@@ -15,9 +15,9 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 
-use IFRS\Traits\Segragating;
+use IFRS\Traits\Segregating;
 use IFRS\Traits\ModelTablePrefix;
 
 /**
@@ -37,9 +37,9 @@ use IFRS\Traits\ModelTablePrefix;
  * @property Carbon $destroyed_at
  * @property Carbon $deleted_at
  */
-class Ledger extends Model implements Segragatable
+class Ledger extends Model implements Segregatable
 {
-    use Segragating;
+    use Segregating;
     use SoftDeletes;
     use ModelTablePrefix;
 

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -14,9 +14,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 use IFRS\Interfaces\Recyclable;
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 
-use IFRS\Traits\Segragating;
+use IFRS\Traits\Segregating;
 use IFRS\Traits\Recycling;
 use IFRS\Traits\ModelTablePrefix;
 
@@ -38,9 +38,9 @@ use IFRS\Exceptions\PostedTransaction;
  * @property Carbon $destroyed_at
  * @property Carbon $deleted_at
  */
-class LineItem extends Model implements Recyclable, Segragatable
+class LineItem extends Model implements Recyclable, Segregatable
 {
-    use Segragating;
+    use Segregating;
     use SoftDeletes;
     use Recycling;
     use ModelTablePrefix;

--- a/src/Models/RecycledObject.php
+++ b/src/Models/RecycledObject.php
@@ -25,14 +25,14 @@ namespace IFRS\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 
-use IFRS\Traits\Segragating;
+use IFRS\Traits\Segregating;
 use IFRS\Traits\ModelTablePrefix;
 
-class RecycledObject extends Model implements Segragatable
+class RecycledObject extends Model implements Segregatable
 {
-    use Segragating;
+    use Segregating;
     use SoftDeletes;
     use ModelTablePrefix;
 

--- a/src/Models/ReportingPeriod.php
+++ b/src/Models/ReportingPeriod.php
@@ -16,10 +16,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
 
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 use IFRS\Interfaces\Recyclable;
 
-use IFRS\Traits\Segragating;
+use IFRS\Traits\Segregating;
 use IFRS\Traits\Recycling;
 use IFRS\Traits\ModelTablePrefix;
 
@@ -37,9 +37,9 @@ use IFRS\Exceptions\MissingReportingPeriod;
  * @property Carbon $destroyed_at
  * @property Carbon $deleted_at
  */
-class ReportingPeriod extends Model implements Segragatable, Recyclable
+class ReportingPeriod extends Model implements Segregatable, Recyclable
 {
-    use Segragating;
+    use Segregating;
     use SoftDeletes;
     use Recycling;
     use ModelTablePrefix;

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -17,7 +17,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 use IFRS\Interfaces\Recyclable;
 use IFRS\Interfaces\Assignable;
 use IFRS\Interfaces\Clearable;
@@ -25,7 +25,7 @@ use IFRS\Interfaces\Clearable;
 use IFRS\Traits\Assigning;
 use IFRS\Traits\Clearing;
 use IFRS\Traits\Recycling;
-use IFRS\Traits\Segragating;
+use IFRS\Traits\Segregating;
 use IFRS\Traits\ModelTablePrefix;
 
 use IFRS\Exceptions\MissingLineItem;
@@ -54,9 +54,9 @@ use IFRS\Exceptions\AdjustingReportingPeriod;
  * @property Carbon $destroyed_at
  * @property Carbon $deleted_at
  */
-class Transaction extends Model implements Segragatable, Recyclable, Clearable, Assignable
+class Transaction extends Model implements Segregatable, Recyclable, Clearable, Assignable
 {
-    use Segragating;
+    use Segregating;
     use SoftDeletes;
     use Recycling;
     use Clearing;

--- a/src/Models/Vat.php
+++ b/src/Models/Vat.php
@@ -15,11 +15,11 @@ use IFRS\Exceptions\MissingVatAccount;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-use IFRS\Interfaces\Segragatable;
+use IFRS\Interfaces\Segregatable;
 use IFRS\Interfaces\Recyclable;
 
 use IFRS\Traits\Recycling;
-use IFRS\Traits\Segragating;
+use IFRS\Traits\Segregating;
 use IFRS\Traits\ModelTablePrefix;
 
 /**
@@ -35,9 +35,9 @@ use IFRS\Traits\ModelTablePrefix;
  * @property Carbon $destroyed_at
  * @property Carbon $deleted_at
  */
-class Vat extends Model implements Segragatable, Recyclable
+class Vat extends Model implements Segregatable, Recyclable
 {
-    use Segragating;
+    use Segregating;
     use SoftDeletes;
     use Recycling;
     use ModelTablePrefix;

--- a/src/Traits/Segregating.php
+++ b/src/Traits/Segregating.php
@@ -18,7 +18,7 @@ use IFRS\Scopes\EntityScope;
 
 use IFRS\Exceptions\UnauthorizedUser;
 
-trait Segragating
+trait Segregating
 {
 
     /**
@@ -28,7 +28,7 @@ trait Segragating
      *
      * @codeCoverageIgnore
      */
-    public static function bootSegragating()
+    public static function bootSegregating()
     {
         static::addGlobalScope(new EntityScope);
 


### PR DESCRIPTION
The examples on the readme suggest to do:

```php
$var = new Model(['attr' => 'val'])->save();
```

But its not possible to instantiate and save at the same time, it should be:

```php
$var = Model::create(['attr' => 'val']);
```

Also the word *segr**a**gate* fixed to *segr**e**gate*.