### PR TITLE
Added back entity relationship calls instead of looking up entity_id on Authenticated User

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ Homestead.json
 .phpunit.result.cache
 clover.*
 /.settings
+
+# PHPSTORM
+.idea

--- a/src/Models/Currency.php
+++ b/src/Models/Currency.php
@@ -96,7 +96,7 @@ class Currency extends Model implements Recyclable, Segregatable
     public function save(array $options = []): bool
     {
         if (!isset($this->entity_id) && Auth::user()->entity) {
-            $this->entity_id = Auth::user()->entity_id;
+            $this->entity_id = Auth::user()->entity->id;
         }
 
         return parent::save($options);

--- a/src/Models/RecycledObject.php
+++ b/src/Models/RecycledObject.php
@@ -49,7 +49,7 @@ class RecycledObject extends Model implements Segregatable
      * @var array
      */
     protected $fillable = [
-        'user_id', 'entity_id', 'recyclable_id', 'recyclable_type', 'entity_id',
+        'user_id', 'entity_id', 'recyclable_id', 'recyclable_type',
     ];
 
     /**

--- a/src/Scopes/EntityScope.php
+++ b/src/Scopes/EntityScope.php
@@ -29,7 +29,7 @@ class EntityScope implements Scope
         $model = null;
         $user = Auth::user();
         if (!is_null($user)) {
-            $builder->where('entity_id', Auth::user()->entity_id);
+            $builder->where('entity_id', Auth::user()->entity->id);
         }
     }
 }

--- a/src/Traits/Recycling.php
+++ b/src/Traits/Recycling.php
@@ -41,7 +41,7 @@ trait Recycling
                             RecycledObject::create(
                                 [
                                     'user_id' => $user->id,
-                                    'entity_id' => $user->entity_id,
+                                    'entity_id' => $user->entity->id,
                                     'recyclable_id' => $model->id,
                                     'recyclable_type' => static::class,
                                 ]

--- a/src/Traits/Segregating.php
+++ b/src/Traits/Segregating.php
@@ -41,7 +41,7 @@ trait Segregating
                 }
 
                 if (Auth::check() && is_null($model->entity_id)) {
-                    $model->entity_id = Auth::user()->entity_id;
+                    $model->entity_id = Auth::user()->entity->id;
                 }
             }
         );


### PR DESCRIPTION
Allow custom models with entities, in a scenario where the Authenticated user model does not store the entity_id.

Reffer to #29 
