### PR TITLE
Fixes startDate not parsed issue in income statement

### DIFF
--- a/src/Reports/IncomeStatement.php
+++ b/src/Reports/IncomeStatement.php
@@ -71,7 +71,7 @@ class IncomeStatement extends FinancialStatement
      */
     public function __construct(string $startDate = null, string $endDate = null)
     {
-        $this->period['startDate'] = is_null($startDate) ? ReportingPeriod::periodStart() : $startDate;
+        $this->period['startDate'] = is_null($startDate) ? ReportingPeriod::periodStart() : Carbon::parse($startDate);
         $this->period['endDate'] = is_null($endDate) ? Carbon::now() : Carbon::parse($endDate);
 
         $period = ReportingPeriod::where("calendar_year", $endDate)->first();


### PR DESCRIPTION
The string $startDate was not parsed prior to the call format() on it in FinancialStatement.php

https://github.com/ekmungai/eloquent-ifrs/blob/5e19848ce5ec1e989041fc14ba20b6d5542e8fcd/src/Reports/IncomeStatement.php#L74

https://github.com/ekmungai/eloquent-ifrs/blob/5e19848ce5ec1e989041fc14ba20b6d5542e8fcd/src/Reports/FinancialStatement.php#L91



```php
public function __construct(string $startDate = null, string $endDate = null)
    {
        //$this->period['startDate'] = is_null($startDate) ? ReportingPeriod::periodStart() : $startDate;
        $this->period['startDate'] = is_null($startDate) ? ReportingPeriod::periodStart() : Carbon::parse($startDate);
     ........
```


