### PR TITLE
Update: Proposed solution for custom hashing algorithms to hash ledger

### DIFF
--- a/config/ifrs.php
+++ b/config/ifrs.php
@@ -105,7 +105,7 @@ return [
      | The Hashing Algorim to be used when hashing Ledger records.
      |
      */
-    'hashing_algorithm' => env('HASHING_ALGORITHM', PASSWORD_DEFAULT),
+    'hashing_algorithm' => env('HASHING_ALGORITHM', 'sha256'),
 
     /*
      |--------------------------------------------------------------------------

--- a/src/Models/Ledger.php
+++ b/src/Models/Ledger.php
@@ -132,10 +132,7 @@ class Ledger extends Model implements Segregatable
     {
         parent::save();
 
-        $this->hash = password_hash(
-            $this->hashed(),
-            config('ifrs')['hashing_algorithm']
-        );
+        $this->hash = hash(config('ifrs')['hashing_algorithm'],$this->hashed());
 
         return parent::save();
     }

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -724,7 +724,7 @@ class Transaction extends Model implements Segregatable, Recyclable, Clearable, 
                 // echo PHP_EOL;
                 // echo $ledger->hashed();
                 // echo PHP_EOL;
-                return password_verify($ledger->hashed(), $ledger->hash);
+                return hash(config('ifrs')['hashing_algorithm'],$ledger->hashed()) == $ledger->hash;
             }
         );
     }


### PR DESCRIPTION
Uses **hash** instead of **password_hash**  to hash ledger.
Improves ledger hashing performance while giving the user more options to use their proffered hashing algorithm.

For more information https://www.php.net/manual/en/function.hash.php