### PR TITLE
Added indexes to transaction model

### DIFF
--- a/database/migrations/2021_09_04_064310_remove_vat_id_column.php
+++ b/database/migrations/2021_09_04_064310_remove_vat_id_column.php
@@ -16,7 +16,7 @@ class RemoveVatIdColumn extends Migration
         Schema::table(config('ifrs.table_prefix') . 'line_items', function (Blueprint $table) {
             
             if (config('database.default') !== 'sqlite') {
-                $table->dropForeign('vats_vat_id_foreign'); // sqlite does not support dropping foregn keys
+                $table->dropForeign(['vat_id']); // sqlite does not support dropping foregn keys
             }
             $table->dropColumn('vat_id');
         });
@@ -30,7 +30,7 @@ class RemoveVatIdColumn extends Migration
     public function down()
     {
         Schema::table(config('ifrs.table_prefix') . 'line_items', function (Blueprint $table) {
-            $table->unsignedBigInteger('vat_id')->nullable();  
+            $table->unsignedBigInteger('vat_id')->nullable();
             $table->foreign('vat_id')->references('id')->on(config('ifrs.table_prefix') . 'vats');
 
         });

--- a/database/migrations/2021_11_15_184418_add_indexes_to_transactions_table.php
+++ b/database/migrations/2021_11_15_184418_add_indexes_to_transactions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndexesToTransactionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(config('ifrs.table_prefix').'transactions', function (Blueprint $table) {
+            $table->index(['transaction_type','transaction_date','entity_id'],"type_date_entity_index");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(config('ifrs.table_prefix').'transactions', function (Blueprint $table) {
+            $table->dropIndex('type_date_entity_index');
+        });
+    }
+}


### PR DESCRIPTION
Hey Edward.
I have added the required indexes to the **Transaction** model in order to increase the performance while saving transactions.
You wouldn't notice much of a difference at first while you're using without these indexes ( a few thousand transactions ) but once the transactions increase in size it slows down exponentially. 

While saving a transaction, the code for generating a new transaction_no looks up these rows from the DB, making it slower for a new transaction to save without an index in a large transactions table.

FYI, the remove vat id column migration has some issues, it throws an error saying vats_vat_id_foreign key does not exist.
I have a written a fix for that too.

Regards