### PR TITLE
Take into consideration apps that use UUIDs for User primary column

### DIFF
--- a/database/migrations/2020_01_10_213405_create_ifrs_recycled_objects_table.php
+++ b/database/migrations/2020_01_10_213405_create_ifrs_recycled_objects_table.php
@@ -34,9 +34,11 @@ class CreateIfrsRecycledObjectsTable extends Migration
                 $version = strpos($versionString, "Components") > 0 ? substr($versionString, 7, 1) : $versionString;
                 $userModel = is_array(config('ifrs.user_model')) ? config('ifrs.user_model')[intval($version)] : config('ifrs.user_model');
                 $type = Schema::getColumnType((new $userModel())->getTable(),'id');
-                if($type == "integer"){
+                if ($type == 'integer') {
                     $table->unsignedInteger('user_id');
-                }else{
+                } elseif ($type === 'string') {
+                    $table->uuid('user_id');
+                } else {
                     $table->unsignedBigInteger('user_id');
                 }
 
@@ -48,7 +50,13 @@ class CreateIfrsRecycledObjectsTable extends Migration
                 $table->foreign('user_id')->references('id')->on((new $userModel())->getTable());
 
                 // attributes
-                $table->bigInteger('recyclable_id');
+                if ($type === 'integer') {
+                    $table->unsignedInteger('recyclable_id');
+                } elseif ($type === 'string') {
+                    $table->uuid('recyclable_id');
+                } else {
+                    $table->bigInteger('recyclable_id');
+                }
                 $table->string('recyclable_type', 300);
 
                 // *permanent* deletion

--- a/database/migrations/2020_01_10_213405_create_ifrs_recycled_objects_table.php
+++ b/database/migrations/2020_01_10_213405_create_ifrs_recycled_objects_table.php
@@ -34,7 +34,7 @@ class CreateIfrsRecycledObjectsTable extends Migration
                 $version = strpos($versionString, "Components") > 0 ? substr($versionString, 7, 1) : $versionString;
                 $userModel = is_array(config('ifrs.user_model')) ? config('ifrs.user_model')[intval($version)] : config('ifrs.user_model');
                 $type = Schema::getColumnType((new $userModel())->getTable(),'id');
-                if ($type == 'integer') {
+                if ($type === 'integer') {
                     $table->unsignedInteger('user_id');
                 } elseif ($type === 'string') {
                     $table->uuid('user_id');


### PR DESCRIPTION
## Background

If an app uses UUIDs for the users' table, migration will fail.

## Change

We take into consideration if the User's model uses `string` type for its primary key. If string, then it's a UUID column.