### PR TITLE
Specify entity_id table in joins

### DIFF
--- a/src/Scopes/EntityScope.php
+++ b/src/Scopes/EntityScope.php
@@ -28,9 +28,9 @@ class EntityScope implements Scope
     {
         $user = Auth::user();
         if(!is_null($model->entity_id)){
-            $builder->where('entity_id', $model->entity_id);
+            $builder->where($model->getTable().'.entity_id', $model->entity_id);
         }elseif(!is_null($user)){
-            $builder->where('entity_id', $user->entity->id);
+            $builder->where($model->getTable().'.entity_id', $user->entity->id);
         }
     }
 }


### PR DESCRIPTION
When you perform join queries between two tables which have the ```entity_id``` column  e.g. Account and Currency to display currency name, the injected ```where entity_id = 7``` leads to an ambiguous column error.

This patch tries to address this challenge by being specific about which table column to reference.