### PR TITLE
fix: use explicit nullable types to avoid PHP 8.1 deprecation warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "octax-app/laravel-accounting",
+    "name": "ekmungai/eloquent-ifrs",
     "description": "Eloquent Double Entry Accounting with focus on IFRS Compliant Reporting",
     "keywords": [
         "accounting",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ekmungai/eloquent-ifrs",
+    "name": "octax-app/laravel-accounting",
     "description": "Eloquent Double Entry Accounting with focus on IFRS Compliant Reporting",
     "keywords": [
         "accounting",

--- a/src/Exceptions/AdjustingReportingPeriod.php
+++ b/src/Exceptions/AdjustingReportingPeriod.php
@@ -21,7 +21,7 @@ class AdjustingReportingPeriod extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $type = Transaction::getType(Transaction::JN);
         $error = "Only " . $type . " Transactions can be posted to a reporting period whose status is " . ReportingPeriod::ADJUSTING;

--- a/src/Exceptions/ClosedReportingPeriod.php
+++ b/src/Exceptions/ClosedReportingPeriod.php
@@ -19,7 +19,7 @@ class ClosedReportingPeriod extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(int $year, string $message = null, int $code = null)
+    public function __construct(int $year, ?string $message = null, ?int $code = null)
     {
         $error = "Transaction cannot be saved because the Reporting Period for " . $year . " is closed ";
 

--- a/src/Exceptions/DuplicateClosingRate.php
+++ b/src/Exceptions/DuplicateClosingRate.php
@@ -20,7 +20,7 @@ class DuplicateClosingRate extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $currencyCode, int $year, string $message = null, int $code = null)
+    public function __construct(string $currencyCode, int $year, ?string $message = null, ?int $code = null)
     {
         $error = "A Closing Rate already exists for " . $currencyCode . " for " . $year;
 

--- a/src/Exceptions/HangingClearances.php
+++ b/src/Exceptions/HangingClearances.php
@@ -18,7 +18,7 @@ class HangingClearances extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Transaction cannot be deleted because it has been used to to Clear other Transactions ";
 

--- a/src/Exceptions/HangingTransactions.php
+++ b/src/Exceptions/HangingTransactions.php
@@ -18,7 +18,7 @@ class HangingTransactions extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Account cannot be deleted because it has existing Transactions/Balances in the current Reporting Period ";
 

--- a/src/Exceptions/IFRSException.php
+++ b/src/Exceptions/IFRSException.php
@@ -40,7 +40,7 @@ abstract class IFRSException extends \Exception
      * @param int $code
      */
 
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         Log::notice(
             $message,

--- a/src/Exceptions/InsufficientBalance.php
+++ b/src/Exceptions/InsufficientBalance.php
@@ -28,7 +28,7 @@ class InsufficientBalance extends IFRSException
         string $transactionType,
         float $amount,
         string $assignedType,
-        string $message = null,
+        ?string $message = null,
         int $code = 0
     )
     {

--- a/src/Exceptions/InvalidAccountClassBalance.php
+++ b/src/Exceptions/InvalidAccountClassBalance.php
@@ -18,7 +18,7 @@ class InvalidAccountClassBalance extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Income Statement Accounts cannot have Opening Balances ";
 

--- a/src/Exceptions/InvalidAccountType.php
+++ b/src/Exceptions/InvalidAccountType.php
@@ -23,7 +23,7 @@ class InvalidAccountType extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct($accountName, $accountTypes, string $message = null, int $code = null)
+    public function __construct($accountName, $accountTypes, ?string $message = null, ?int $code = null)
     {
         $error = $accountName . ' Account';
         if (is_array($accountTypes)) {

--- a/src/Exceptions/InvalidBalanceDate.php
+++ b/src/Exceptions/InvalidBalanceDate.php
@@ -19,7 +19,7 @@ class InvalidBalanceDate extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Transaction date must be earlier than the first day of the Balance's Reporting Period ";
 

--- a/src/Exceptions/InvalidBalanceTransaction.php
+++ b/src/Exceptions/InvalidBalanceTransaction.php
@@ -22,7 +22,7 @@ class InvalidBalanceTransaction extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(array $transactionTypes, string $message = null, int $code = null)
+    public function __construct(array $transactionTypes, ?string $message = null, ?int $code = null)
     {
         $transactionTypes = Transaction::getTypes($transactionTypes);
 

--- a/src/Exceptions/InvalidBalanceType.php
+++ b/src/Exceptions/InvalidBalanceType.php
@@ -22,7 +22,7 @@ class InvalidBalanceType extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(array $balanceTypes, string $message = null, int $code = null)
+    public function __construct(array $balanceTypes, ?string $message = null, ?int $code = null)
     {
         $balanceTypes = Balance::getTypes($balanceTypes);
 

--- a/src/Exceptions/InvalidCategoryType.php
+++ b/src/Exceptions/InvalidCategoryType.php
@@ -23,7 +23,7 @@ class InvalidCategoryType extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $accountType, string $categoryType, string $message = null, int $code = null)
+    public function __construct(string $accountType, string $categoryType, ?string $message = null, ?int $code = null)
     {
         $error = "Cannot assign " . Account::getType($accountType) . " Account to " . Account::getType($categoryType) . " Category";
 

--- a/src/Exceptions/InvalidClearanceAccount.php
+++ b/src/Exceptions/InvalidClearanceAccount.php
@@ -18,7 +18,7 @@ class InvalidClearanceAccount extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Assignment and Clearance Main Account must be the same ";
 

--- a/src/Exceptions/InvalidClearanceCurrency.php
+++ b/src/Exceptions/InvalidClearanceCurrency.php
@@ -18,7 +18,7 @@ class InvalidClearanceCurrency extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Assignment and Clearance Currency must be the same ";
 

--- a/src/Exceptions/InvalidClearanceEntry.php
+++ b/src/Exceptions/InvalidClearanceEntry.php
@@ -17,7 +17,7 @@ class InvalidClearanceEntry extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Transaction Entry increases the Main Account outstanding balance instead of reducing it ";
 

--- a/src/Exceptions/InvalidCurrency.php
+++ b/src/Exceptions/InvalidCurrency.php
@@ -22,7 +22,7 @@ class InvalidCurrency extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $changeType, Account $account, string $message = null, int $code = null)
+    public function __construct(string $changeType, Account $account, ?string $message = null, ?int $code = null)
     {
         $error = $changeType. " Currency must be the same as the ".$account->toString(true)." Account Currency ";
 

--- a/src/Exceptions/InvalidPeriodStatus.php
+++ b/src/Exceptions/InvalidPeriodStatus.php
@@ -20,7 +20,7 @@ class InvalidPeriodStatus extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Reporting Period must have " . config('ifrs')['reporting_period_status'][ReportingPeriod::ADJUSTING] . " status to translate foreign balances";
 

--- a/src/Exceptions/InvalidTransaction.php
+++ b/src/Exceptions/InvalidTransaction.php
@@ -18,7 +18,7 @@ class InvalidTransaction extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Compound Journal Entry Transactions can be neither Assigned nor Cleared ";
 

--- a/src/Exceptions/InvalidTransactionDate.php
+++ b/src/Exceptions/InvalidTransactionDate.php
@@ -19,7 +19,7 @@ class InvalidTransactionDate extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Transaction date cannot be at the beginning of the first day of the Reporting Period. Use a Balance object instead ";
 

--- a/src/Exceptions/InvalidTransactionType.php
+++ b/src/Exceptions/InvalidTransactionType.php
@@ -18,7 +18,7 @@ class InvalidTransactionType extends IFRSException
      * @param string $message
      * @param int    $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Transaction Type cannot be edited";
 

--- a/src/Exceptions/InvalidVatRate.php
+++ b/src/Exceptions/InvalidVatRate.php
@@ -18,7 +18,7 @@ class InvalidVatRate extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Compound Journal Entry Vat objects must all be null or zero rated ";
 

--- a/src/Exceptions/LineItemAccount.php
+++ b/src/Exceptions/LineItemAccount.php
@@ -23,7 +23,7 @@ class LineItemAccount extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $transactionType, array $accountTypes, string $message = null, int $code = null)
+    public function __construct(string $transactionType, array $accountTypes, ?string $message = null, ?int $code = null)
     {
         $transactionType = Transaction::getType($transactionType);
         $accountTypes = Account::getTypes($accountTypes);

--- a/src/Exceptions/MainAccount.php
+++ b/src/Exceptions/MainAccount.php
@@ -23,7 +23,7 @@ class MainAccount extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $transactionType, string $accountType, string $message = null, int $code = null)
+    public function __construct(string $transactionType, string $accountType, ?string $message = null, ?int $code = null)
     {
         $transactionType = Transaction::getType($transactionType);
         $accountType = Account::getType($accountType);

--- a/src/Exceptions/MissingAccount.php
+++ b/src/Exceptions/MissingAccount.php
@@ -19,7 +19,7 @@ class MissingAccount extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $statementType, string $message = null, int $code = null)
+    public function __construct(string $statementType, ?string $message = null, ?int $code = null)
     {
         $error = $statementType . " Transactions require an Account ";
 

--- a/src/Exceptions/MissingAccountType.php
+++ b/src/Exceptions/MissingAccountType.php
@@ -18,7 +18,7 @@ class MissingAccountType extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Account type is Required ";
 

--- a/src/Exceptions/MissingClosingRate.php
+++ b/src/Exceptions/MissingClosingRate.php
@@ -19,7 +19,7 @@ class MissingClosingRate extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $currencyCode, string $message = null, int $code = null)
+    public function __construct(string $currencyCode, ?string $message = null, ?int $code = null)
     {
         $error = "Closing Rate for " . $currencyCode . " is missing  ";
 

--- a/src/Exceptions/MissingForexAccount.php
+++ b/src/Exceptions/MissingForexAccount.php
@@ -20,7 +20,7 @@ class MissingForexAccount extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "A Forex Differences Account of type '". Account::getType(Account::NON_OPERATING_REVENUE). "' is required for Assignment Transactions with different exchange rates ";
 

--- a/src/Exceptions/MissingLineItem.php
+++ b/src/Exceptions/MissingLineItem.php
@@ -18,10 +18,10 @@ class MissingLineItem extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "A Transaction must have at least one LineItem to be posted ";
 
-        parent::__construct($error . $message, $code = null);
+        parent::__construct($error . $message, $code);
     }
 }

--- a/src/Exceptions/MissingMainAccountAmount.php
+++ b/src/Exceptions/MissingMainAccountAmount.php
@@ -18,7 +18,7 @@ class MissingMainAccountAmount extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Compund Journal Entries must have a Main Account Amount ";
 

--- a/src/Exceptions/MissingReportingCurrency.php
+++ b/src/Exceptions/MissingReportingCurrency.php
@@ -19,7 +19,7 @@ class MissingReportingCurrency extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $entity, string $message = null, int $code = null)
+    public function __construct(string $entity, ?string $message = null, ?int $code = null)
     {
         $error = "Entity '" . $entity . "' has no Reporting Currency defined ";
 

--- a/src/Exceptions/MissingReportingPeriod.php
+++ b/src/Exceptions/MissingReportingPeriod.php
@@ -20,7 +20,7 @@ class MissingReportingPeriod extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $entity, int $year, string $message = null, int $code = null)
+    public function __construct(string $entity, int $year, ?string $message = null, ?int $code = null)
     {
         $error = "Entity '" . $entity . "' has no reporting period defined for the year " . $year . " ";
 

--- a/src/Exceptions/MissingVatAccount.php
+++ b/src/Exceptions/MissingVatAccount.php
@@ -19,7 +19,7 @@ class MissingVatAccount extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(float $vatRate, string $message = null, int $code = null)
+    public function __construct(float $vatRate, ?string $message = null, ?int $code = null)
     {
         $error = $vatRate . "% VAT requires a Vat Account ";
 

--- a/src/Exceptions/MixedAssignment.php
+++ b/src/Exceptions/MixedAssignment.php
@@ -20,7 +20,7 @@ class MixedAssignment extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $previous, string $current, string $message = null, int $code = null)
+    public function __construct(string $previous, string $current, ?string $message = null, ?int $code = null)
     {
         $error = "A Transaction that has been " . $previous . " cannot be " . $current;
 

--- a/src/Exceptions/MultipleVatError.php
+++ b/src/Exceptions/MultipleVatError.php
@@ -18,7 +18,7 @@ class MultipleVatError extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $error, string $message = null, int $code = null)
+    public function __construct(string $error, ?string $message = null, ?int $code = null)
     {
         parent::__construct($error . ' ' . $message, $code);
     }

--- a/src/Exceptions/NegativeAmount.php
+++ b/src/Exceptions/NegativeAmount.php
@@ -19,7 +19,7 @@ class NegativeAmount extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $modelType, string $message = null, int $code = null)
+    public function __construct(string $modelType, ?string $message = null, ?int $code = null)
     {
         $error = $modelType . " Amount cannot be negative ";
 

--- a/src/Exceptions/NegativeQuantity.php
+++ b/src/Exceptions/NegativeQuantity.php
@@ -19,7 +19,7 @@ class NegativeQuantity extends IFRSException
      * @param string $message
      * @param int    $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "LineItem Quantity cannot be negative ";
 

--- a/src/Exceptions/OverClearance.php
+++ b/src/Exceptions/OverClearance.php
@@ -22,7 +22,7 @@ class OverClearance extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $assignedType, float $amount, string $message = null, int $code = null)
+    public function __construct(string $assignedType, float $amount, ?string $message = null, ?int $code = null)
     {
         $assignedType = Transaction::getType($assignedType);
 

--- a/src/Exceptions/PostedTransaction.php
+++ b/src/Exceptions/PostedTransaction.php
@@ -19,7 +19,7 @@ class PostedTransaction extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $action, string $message = null, int $code = null)
+    public function __construct(string $action, ?string $message = null, ?int $code = null)
     {
         $error = "Cannot " . $action . " a posted Transaction ";
 

--- a/src/Exceptions/RedundantTransaction.php
+++ b/src/Exceptions/RedundantTransaction.php
@@ -18,10 +18,10 @@ class RedundantTransaction extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "A Transaction Main Account cannot be one of the Line Item Accounts ";
 
-        parent::__construct($error . $message, $code = null);
+        parent::__construct($error . $message, $code);
     }
 }

--- a/src/Exceptions/SelfClearance.php
+++ b/src/Exceptions/SelfClearance.php
@@ -18,7 +18,7 @@ class SelfClearance extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Transaction cannot be used to clear itself ";
 

--- a/src/Exceptions/UnassignableTransaction.php
+++ b/src/Exceptions/UnassignableTransaction.php
@@ -22,7 +22,7 @@ class UnassignableTransaction extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $transactionType, array $transactionTypes, string $message = null, int $code = null)
+    public function __construct(string $transactionType, array $transactionTypes, ?string $message = null, ?int $code = null)
     {
         $transactionTypes = Transaction::getTypes($transactionTypes);
         $transactionType = Transaction::getType($transactionType);

--- a/src/Exceptions/UnauthorizedUser.php
+++ b/src/Exceptions/UnauthorizedUser.php
@@ -18,7 +18,7 @@ class UnauthorizedUser extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = 'You are not Authorized to perform that action ';
 

--- a/src/Exceptions/UnbalancedTransaction.php
+++ b/src/Exceptions/UnbalancedTransaction.php
@@ -18,7 +18,7 @@ class UnbalancedTransaction extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "Total Debit amounts do not match total Credit amounts ";
 

--- a/src/Exceptions/UnclearableTransaction.php
+++ b/src/Exceptions/UnclearableTransaction.php
@@ -22,7 +22,7 @@ class UnclearableTransaction extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $transactionType, array $transactionTypes, string $message = null, int $code = null)
+    public function __construct(string $transactionType, array $transactionTypes, ?string $message = null, ?int $code = null)
     {
         $transactionTypes = Transaction::getTypes($transactionTypes);
         $transactionType = Transaction::getType($transactionType);

--- a/src/Exceptions/UnconfiguredLocale.php
+++ b/src/Exceptions/UnconfiguredLocale.php
@@ -19,7 +19,7 @@ class UnconfiguredLocale extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $locale, string $message = null, int $code = null)
+    public function __construct(string $locale, ?string $message = null, ?int $code = null)
     {
         $error = "Locale " . $locale . " is not configured";
 

--- a/src/Exceptions/UnpostedAssignment.php
+++ b/src/Exceptions/UnpostedAssignment.php
@@ -18,7 +18,7 @@ class UnpostedAssignment extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "An Unposted Transaction cannot be Assigned or Cleared ";
 

--- a/src/Exceptions/VatCharge.php
+++ b/src/Exceptions/VatCharge.php
@@ -21,7 +21,7 @@ class VatCharge extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct($transactionType, string $message = null, int $code = null)
+    public function __construct($transactionType, ?string $message = null, ?int $code = null)
     {
         $transactionType = Transaction::getType($transactionType);
 

--- a/src/Exceptions/VatPeriodOverlap.php
+++ b/src/Exceptions/VatPeriodOverlap.php
@@ -18,7 +18,7 @@ class VatPeriodOverlap extends IFRSException
      * @param string $message
      * @param int $code
      */
-    public function __construct(string $message = null, int $code = null)
+    public function __construct(?string $message = null, ?int $code = null)
     {
         $error = "A VAT record already exists for that period";
 

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -144,7 +144,7 @@ class Account extends Model implements Recyclable, Segregatable
      *
      * @return array
      */
-    public static function openingBalances(int $year, Entity $entity = null)
+    public static function openingBalances(int $year, ?Entity $entity = null)
     {
         if (is_null($entity)) {
             $entity = Auth::user()->entity;
@@ -182,7 +182,7 @@ class Account extends Model implements Recyclable, Segregatable
         $startDate = null,
         $endDate = null,
         $fullBalance = true,
-        Entity $entity = null
+        ?Entity $entity = null
     ): array
     {
 
@@ -306,7 +306,7 @@ class Account extends Model implements Recyclable, Segregatable
      *
      * @return array
      */
-    public function closingBalance(string $endDate = null, int $currencyId = null): array
+    public function closingBalance(?string $endDate = null, ?int $currencyId = null): array
     {
         $entity = $this->entity;
 
@@ -329,7 +329,7 @@ class Account extends Model implements Recyclable, Segregatable
      *
      * @return array
      */
-    public function openingBalance(int $year = null, int $currencyId = null): array
+    public function openingBalance(?int $year = null, ?int $currencyId = null): array
     {
         $entity = $this->entity;
 
@@ -375,7 +375,7 @@ class Account extends Model implements Recyclable, Segregatable
      *
      * @return array
      */
-    public function currentBalance(Carbon $startDate = null, Carbon $endDate = null, int $currencyId = null): array
+    public function currentBalance(?Carbon $startDate = null, ?Carbon $endDate = null, ?int $currencyId = null): array
     {
         $entity = $this->entity;
 
@@ -390,7 +390,7 @@ class Account extends Model implements Recyclable, Segregatable
      * @param int $year
      *
      */
-    public function isClosed(int $year = null): bool
+    public function isClosed(?int $year = null): bool
     {
         if (is_null($year)) {
             $year = $this->entity->current_reporting_period->calendar_year;
@@ -423,7 +423,7 @@ class Account extends Model implements Recyclable, Segregatable
      * @param int $year
      *
      */
-    public function closingTransactions(int $year = null): array
+    public function closingTransactions(?int $year = null): array
     {
         if (is_null($year)) {
             $year = $this->entity->current_reporting_period->calendar_year;
@@ -461,7 +461,7 @@ class Account extends Model implements Recyclable, Segregatable
      *
      * @return array
      */
-    public function getTransactions(string $startDate = null, string $endDate = null): array
+    public function getTransactions(?string $startDate = null, ?string $endDate = null): array
     {
 
         $startDate = is_null($startDate) ? ReportingPeriod::periodStart($endDate, $this->entity) : Carbon::parse($startDate);
@@ -479,7 +479,7 @@ class Account extends Model implements Recyclable, Segregatable
      *
      * @return Builder
      */
-    public function transactionsQuery(Carbon $startDate, Carbon $endDate, int $currencyId = null)
+    public function transactionsQuery(Carbon $startDate, Carbon $endDate, ?int $currencyId = null)
     {
         $transactionsTable = config('ifrs.table_prefix') . 'transactions';
         $ledgerTable = config('ifrs.table_prefix') . 'ledgers';

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -100,7 +100,7 @@ class Category extends Model implements Segregatable, Recyclable
      *
      * @return array
      */
-    public function getAccountBalances(Carbon $startDate = null, Carbon $endDate = null)
+    public function getAccountBalances(?Carbon $startDate = null, ?Carbon $endDate = null)
     {
         $balances = ["total" => 0, "accounts" => []];
 

--- a/src/Models/Entity.php
+++ b/src/Models/Entity.php
@@ -214,7 +214,7 @@ class Entity extends Model implements Recyclable
      * @param string $locale
      * @return string
      */
-    public function localizeAmount(float $amount, string $currencyCode = null, $locale = null)
+    public function localizeAmount(float $amount, ?string $currencyCode = null, $locale = null)
     {
         if (is_null($locale)) {
             $locale = $this->locale;

--- a/src/Models/Ledger.php
+++ b/src/Models/Ledger.php
@@ -353,7 +353,7 @@ private static function allocateAmount($postAccount, $amount, $posts, $folios, $
      *
      * @return float
      */
-    public static function contribution(Account $account, int $transactionId, int $currencyId = null): float
+    public static function contribution(Account $account, int $transactionId, ?int $currencyId = null): float
     {
         $ledger = new Ledger();
 
@@ -383,7 +383,7 @@ private static function allocateAmount($postAccount, $amount, $posts, $folios, $
      *
      * @return array
      */
-    public static function balance(Account $account, Carbon $startDate, Carbon $endDate, int $currencyId = null): array
+    public static function balance(Account $account, Carbon $startDate, Carbon $endDate, ?int $currencyId = null): array
     {
         $ledger = new Ledger();
         $entity = $account->entity;

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -79,7 +79,7 @@ class LineItem extends Model implements Recyclable, Segregatable
      *
      * @return int|false
      */
-    private function vatExists(int $id = null)
+    private function vatExists(?int $id = null)
     {
         return collect($this->vats)->search(
             function ($vat, $key) use ($id) {

--- a/src/Models/ReportingPeriod.php
+++ b/src/Models/ReportingPeriod.php
@@ -90,7 +90,7 @@ class ReportingPeriod extends Model implements Segregatable, Recyclable
      * @param string|Carbon $date
      * @return ReportingPeriod
      */
-    public static function getPeriod($date = null, Entity $entity = null)
+    public static function getPeriod($date = null, ?Entity $entity = null)
     {
         if (is_null($entity)) {
             $entity = Auth::user()->entity;
@@ -113,7 +113,7 @@ class ReportingPeriod extends Model implements Segregatable, Recyclable
      *
      * @return int
      */
-    public static function year($date = null, Entity $entity = null)
+    public static function year($date = null, ?Entity $entity = null)
     {
         if (is_null($entity)) {
             $entity = Auth::user()->entity;
@@ -224,7 +224,7 @@ class ReportingPeriod extends Model implements Segregatable, Recyclable
      *
      * @return array $transactions
      */
-    public function prepareBalancesTranslation($forexAccountId, int $accountId = null): array
+    public function prepareBalancesTranslation($forexAccountId, ?int $accountId = null): array
     {
 
         if (Account::find($forexAccountId)->account_type != Account::EQUITY) {
@@ -313,7 +313,7 @@ class ReportingPeriod extends Model implements Segregatable, Recyclable
      *
      * @return Carbon
      */
-    public static function periodEnd($date = null, Entity $entity = null)
+    public static function periodEnd($date = null, ?Entity $entity = null)
     {
         return ReportingPeriod::periodStart($date, $entity)
             ->addYear()
@@ -325,7 +325,7 @@ class ReportingPeriod extends Model implements Segregatable, Recyclable
      *
      * @return Carbon $date
      */
-    public static function periodStart($date = null, Entity $entity = null)
+    public static function periodStart($date = null, ?Entity $entity = null)
     {
         if (is_null($entity)) {
             if (Auth::user()) {

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -150,7 +150,7 @@ class Transaction extends Model implements Segregatable, Recyclable, Clearable, 
      *
      * @return int|false
      */
-    private function lineItemExists(int $id = null)
+    private function lineItemExists(?int $id = null)
     {
         return collect($this->items)->search(
             function ($item, $key) use ($id) {
@@ -166,7 +166,7 @@ class Transaction extends Model implements Segregatable, Recyclable, Clearable, 
      *
      * @return int|false
      */
-    private function assignedTransactionExists(int $id = null)
+    private function assignedTransactionExists(?int $id = null)
     {
         return collect($this->assigned)->search(
             function ($transaction, $key) use ($id) {
@@ -656,7 +656,7 @@ class Transaction extends Model implements Segregatable, Recyclable, Clearable, 
      *
      * @return null
      */
-    public function processAssigned(int $forexAccountId = null): void
+    public function processAssigned(?int $forexAccountId = null): void
     {
         foreach ($this->assigned as $outstanding) {
             $cleared = Transaction::find($outstanding['id']);
@@ -772,7 +772,7 @@ class Transaction extends Model implements Segregatable, Recyclable, Clearable, 
      *
      * @return string
      */
-    public static function transactionNo(string $type, Carbon $transaction_date = null, Entity $entity = null)
+    public static function transactionNo(string $type, ?Carbon $transaction_date = null, ?Entity $entity = null)
     {
         if (is_null($entity)) {
             $entity = Auth::user()->entity;

--- a/src/Reports/AccountSchedule.php
+++ b/src/Reports/AccountSchedule.php
@@ -43,7 +43,7 @@ class AccountSchedule extends AccountStatement
      * @param int $currencyId
      * @param string $endDate
      */
-    public function __construct(int $accountId = null, int $currencyId = null, string $endDate = null)
+    public function __construct(?int $accountId = null, ?int $currencyId = null, ?string $endDate = null)
     {
         if (is_null($accountId)) {
             throw new MissingAccount("Account Schedule");

--- a/src/Reports/AccountStatement.php
+++ b/src/Reports/AccountStatement.php
@@ -76,10 +76,10 @@ class AccountStatement
      * @param string $endDate
      */
     public function __construct(
-        int $accountId = null,
-        int $currencyId = null,
-        string $startDate = null,
-        string $endDate = null
+        ?int $accountId = null,
+        ?int $currencyId = null,
+        ?string $startDate = null,
+        ?string $endDate = null
     )
     {
         if (is_null($accountId)) {

--- a/src/Reports/AgingSchedule.php
+++ b/src/Reports/AgingSchedule.php
@@ -59,7 +59,7 @@ class AgingSchedule
      * @param string $endDate
      * @param Entity $entity
      */
-    public function __construct(string $accountType = Account::RECEIVABLE, string $endDate = null, int $currencyId = null, Entity $entity = null)
+    public function __construct(string $accountType = Account::RECEIVABLE, ?string $endDate = null, ?int $currencyId = null, ?Entity $entity = null)
     {
         if (is_null($entity)) {
             $this->entity = Auth::user()->entity;

--- a/src/Reports/BalanceSheet.php
+++ b/src/Reports/BalanceSheet.php
@@ -56,7 +56,7 @@ class BalanceSheet extends FinancialStatement
      * @param string $endDate
      * @param Entity $entity
      */
-    public function __construct(string $endDate = null, Entity $entity = null)
+    public function __construct(?string $endDate = null, ?Entity $entity = null)
     {
         $this->period['startDate'] = ReportingPeriod::periodStart($endDate, $entity);
         $this->period['endDate'] = is_null($endDate) ? ReportingPeriod::periodEnd(null, $entity) : Carbon::parse($endDate);

--- a/src/Reports/CashFlowStatement.php
+++ b/src/Reports/CashFlowStatement.php
@@ -76,7 +76,7 @@ class CashFlowStatement extends FinancialStatement
      * @param string $endDate
      * @param Entity $entity
      */
-    public function __construct(string $startDate = null, string $endDate = null, Entity $entity = null)
+    public function __construct(?string $startDate = null, ?string $endDate = null, ?Entity $entity = null)
     {
         $this->period['startDate'] = is_null($startDate) ? ReportingPeriod::periodStart(null, $entity) : Carbon::parse($startDate);
         $this->period['endDate'] = is_null($endDate) ? Carbon::now() : Carbon::parse($endDate);

--- a/src/Reports/FinancialStatement.php
+++ b/src/Reports/FinancialStatement.php
@@ -68,7 +68,7 @@ abstract class FinancialStatement
      *
      * @param ReportingPeriod $period
      */
-    public function __construct(ReportingPeriod $period = null, Entity $entity = null)
+    public function __construct(?ReportingPeriod $period = null, ?Entity $entity = null)
     {
         if (is_null($entity)) {
             $this->entity = Auth::user()->entity;

--- a/src/Reports/IncomeStatement.php
+++ b/src/Reports/IncomeStatement.php
@@ -60,7 +60,7 @@ class IncomeStatement extends FinancialStatement
      * @param string $endDate
      * @param Entity $entity
      */
-    public function __construct(string $startDate = null, string $endDate = null, Entity $entity = null)
+    public function __construct(?string $startDate = null, ?string $endDate = null, ?Entity $entity = null)
     {
         $this->period['startDate'] = is_null($startDate) ? ReportingPeriod::periodStart(null, $entity) : Carbon::parse($startDate);
         $this->period['endDate'] = is_null($endDate) ? ReportingPeriod::periodEnd(null, $entity) : Carbon::parse($endDate);
@@ -114,7 +114,7 @@ class IncomeStatement extends FinancialStatement
      * @param int|string year
      * @return array
      */
-    public static function getResults($month, $year, Entity $entity = null)
+    public static function getResults($month, $year, ?Entity $entity = null)
     {
         if (is_null($entity)) {
             $entity = Auth::user()->entity;
@@ -147,7 +147,7 @@ class IncomeStatement extends FinancialStatement
      * @param int month
      * @param int year
      */
-    private static function getBalance(array $accountTypes, Carbon $startDate, Carbon $endDate, Entity $entity = null): float
+    private static function getBalance(array $accountTypes, Carbon $startDate, Carbon $endDate, ?Entity $entity = null): float
     {
         if (is_null($entity)) {
             $entity = Auth::user()->entity;

--- a/src/Reports/TrialBalance.php
+++ b/src/Reports/TrialBalance.php
@@ -31,7 +31,7 @@ class TrialBalance extends FinancialStatement
      * @param string $year
      * @param Entity $entity
      */
-    public function __construct(string $year = null, Entity $entity = null)
+    public function __construct(?string $year = null, ?Entity $entity = null)
     {
         $startDate = $year . "-01-01";
         $period = ReportingPeriod::getPeriod(Carbon::parse($startDate), $entity);


### PR DESCRIPTION
Updated function and method signatures to use explicit nullable types (e.g., ?int) where default values were set to null. This resolves deprecation warnings introduced in PHP 8.1 and ensures forward compatibility.
