### PR TITLE
Fix: ensure entity_id is set on Ledger entries during posting of compound journal

### DIFF
--- a/src/Models/Ledger.php
+++ b/src/Models/Ledger.php
@@ -197,6 +197,7 @@ private static function allocateAmount($postAccount, $amount, $posts, $folios, $
             $ledger = new Ledger();
 
             $ledger->transaction_id = $transaction->id;
+            $ledger->entity_id = $transaction->entity_id;
             $ledger->currency_id = $transaction->currency_id;
             $ledger->posting_date = $transaction->transaction_date;
             $ledger->rate = $rate;


### PR DESCRIPTION
This PR fixes an issue where Ledger records are created without an entity_id, which causes SQL errors when posting a compound journal entry.

Related Issue: Fixes #184 