### PR TITLE
Fix: resolve users table name from User model instead of hardcoding table_prefix + 'users'

### DIFF
--- a/database/migrations/2014_10_12_000000_ifrs_create_or_update_users_table.php
+++ b/database/migrations/2014_10_12_000000_ifrs_create_or_update_users_table.php
@@ -1,88 +1,110 @@
-<?php
-/**
- * Eloquent IFRS Accounting
- *
- * @author Edward Mungai
- * @copyright Edward Mungai, 2020, Germany
- * @license MIT
- */
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Schema;
-
-class IfrsCreateOrUpdateUsersTable extends Migration
-{
+    <?php
     /**
-     * Run the migrations.
+     * Eloquent IFRS Accounting
      *
-     * @return void
+     * @author Edward Mungai
+     * @copyright Edward Mungai, 2020, Germany
+     * @license MIT
      */
-    public function up()
+    use Illuminate\Database\Migrations\Migration;
+    use Illuminate\Database\Schema\Blueprint;
+    use Illuminate\Support\Facades\App;
+    use Illuminate\Support\Facades\Schema;
+
+    class IfrsCreateOrUpdateUsersTable extends Migration
     {
-        $userModel = config('ifrs.user_model');
-        $usersTable = (new $userModel())->getTable();
-
-        if (Schema::hasTable($usersTable)) {
-            Schema::table(
-                $usersTable,
-                function (Blueprint $table) {
-                    //entity
-                    $table->unsignedBigInteger('entity_id')->nullable();
-                    // *permanent* deletion
-                    $table->dateTime('destroyed_at')->nullable();
-            });
-        }else{
-            Schema::create(
-                $usersTable,
-                function (Blueprint $table) {
-                    $table->bigIncrements('id');
-
-                    //entity
-                    $table->unsignedBigInteger('entity_id')->nullable();
-
-                    // attributes
-                    $table->string('name');
-                    $table->string('email')->unique();
-                    $table->timestamp('email_verified_at')->nullable();
-                    $table->string('password');
-                    $table->rememberToken();
-
-                    // *permanent* deletion
-                    $table->dateTime('destroyed_at')->nullable();
-
-                    //soft deletion
-                    $table->softDeletes();
-
-                    $table->timestamps();
-
-                    // flag for created table
-                    $table->boolean('created')->nullable();
-            });
-        }
-    }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        $userModel = config('ifrs.user_model');
-        $usersTable = (new $userModel())->getTable();
-
-        if (Schema::hasColumn($usersTable, 'created'))
+        /**
+         * Resolve the users table name from the configured User model.
+         *
+         * Handles both the string format ('App\Models\User') and the legacy
+         * array format ([7 => App\User::class, 8 => App\Models\User::class]).
+         *
+         * @return string
+         */
+        private function getUsersTable()
         {
-            Schema::dropIfExists($usersTable);
-        }else{
-            Schema::table(
-                $usersTable,
-                function (Blueprint $table) {
-                    $table->dropColumn('entity_id');
-                    $table->dropColumn('destroyed_at');
-                }
-            );
+            $userModel = config('ifrs.user_model');
+
+            if (is_array($userModel)) {
+                $major = (int) App::version();
+                $userModel = $userModel[$major] ?? end($userModel);
+            }
+
+            if (is_string($userModel) && class_exists($userModel)) {
+                return (new $userModel())->getTable();
+            }
+
+            return 'users';
+        }
+
+        /**
+         * Run the migrations.
+         *
+         * @return void
+         */
+        public function up()
+        {
+            $usersTable = $this->getUsersTable();
+
+            if (Schema::hasTable($usersTable)) {
+                Schema::table(
+                    $usersTable,
+                    function (Blueprint $table) {
+                        //entity
+                        $table->unsignedBigInteger('entity_id')->nullable();
+                        // *permanent* deletion
+                        $table->dateTime('destroyed_at')->nullable();
+                });
+            }else{
+                Schema::create(
+                    $usersTable,
+                    function (Blueprint $table) {
+                        $table->bigIncrements('id');
+
+                        //entity
+                        $table->unsignedBigInteger('entity_id')->nullable();
+
+                        // attributes
+                        $table->string('name');
+                        $table->string('email')->unique();
+                        $table->timestamp('email_verified_at')->nullable();
+                        $table->string('password');
+                        $table->rememberToken();
+
+                        // *permanent* deletion
+                        $table->dateTime('destroyed_at')->nullable();
+
+                        //soft deletion
+                        $table->softDeletes();
+
+                        $table->timestamps();
+
+                        // flag for created table
+                        $table->boolean('created')->nullable();
+                });
+            }
+        }
+
+        /**
+         * Reverse the migrations.
+         *
+         * @return void
+         */
+        public function down()
+        {
+            $usersTable = $this->getUsersTable();
+
+            if (Schema::hasColumn($usersTable, 'created'))
+            {
+                Schema::dropIfExists($usersTable);
+            }else{
+                Schema::table(
+                    $usersTable,
+                    function (Blueprint $table) {
+                        $table->dropColumn('entity_id');
+                        $table->dropColumn('destroyed_at');
+                    }
+                );
+            }
         }
     }
-}

--- a/database/migrations/2014_10_12_000000_ifrs_create_or_update_users_table.php
+++ b/database/migrations/2014_10_12_000000_ifrs_create_or_update_users_table.php
@@ -20,9 +20,12 @@ class IfrsCreateOrUpdateUsersTable extends Migration
      */
     public function up()
     {
-        if (Schema::hasTable(config('ifrs.table_prefix') . 'users')) {
+        $userModel = config('ifrs.user_model');
+        $usersTable = (new $userModel())->getTable();
+
+        if (Schema::hasTable($usersTable)) {
             Schema::table(
-                config('ifrs.table_prefix') . 'users',
+                $usersTable,
                 function (Blueprint $table) {
                     //entity
                     $table->unsignedBigInteger('entity_id')->nullable();
@@ -31,7 +34,7 @@ class IfrsCreateOrUpdateUsersTable extends Migration
             });
         }else{
             Schema::create(
-                config('ifrs.table_prefix') . 'users',
+                $usersTable,
                 function (Blueprint $table) {
                     $table->bigIncrements('id');
 
@@ -66,12 +69,15 @@ class IfrsCreateOrUpdateUsersTable extends Migration
      */
     public function down()
     {
-        if (Schema::hasColumn(config('ifrs.table_prefix') . 'users', 'created'))
+        $userModel = config('ifrs.user_model');
+        $usersTable = (new $userModel())->getTable();
+
+        if (Schema::hasColumn($usersTable, 'created'))
         {
-            Schema::dropIfExists(config('ifrs.table_prefix') . 'users');
+            Schema::dropIfExists($usersTable);
         }else{
             Schema::table(
-                config('ifrs.table_prefix') . 'users',
+                $usersTable,
                 function (Blueprint $table) {
                     $table->dropColumn('entity_id');
                     $table->dropColumn('destroyed_at');

--- a/database/migrations/2020_01_10_213405_create_ifrs_recycled_objects_table.php
+++ b/database/migrations/2020_01_10_213405_create_ifrs_recycled_objects_table.php
@@ -21,16 +21,19 @@ class CreateIfrsRecycledObjectsTable extends Migration
     public function up()
     {
 
+        $userModel = config('ifrs.user_model');
+        $usersTable = (new $userModel())->getTable();
+
         Schema::create(
             config('ifrs.table_prefix').'recycled_objects',
-            function (Blueprint $table) {
+            function (Blueprint $table) use ($usersTable) {
                 $table->bigIncrements('id');
 
                 // relationships
                 $table->unsignedBigInteger('entity_id');
 
                 // before we set the datatype of this field, we check the existing user's table's id columns datatype
-                $type = Schema::getColumnType(config('ifrs.table_prefix').'users','id');
+                $type = Schema::getColumnType($usersTable,'id');
                 if ($type === 'integer') {
                     $table->unsignedInteger('user_id');
                 } elseif ($type === 'string') {
@@ -41,7 +44,7 @@ class CreateIfrsRecycledObjectsTable extends Migration
 
                 // constraints
                 $table->foreign('entity_id')->references('id')->on(config('ifrs.table_prefix').'entities');
-                $table->foreign('user_id')->references('id')->on(config('ifrs.table_prefix').'users');
+                $table->foreign('user_id')->references('id')->on($usersTable);
 
                 // attributes
                 if ($type === 'integer') {

--- a/database/migrations/2020_01_10_213405_create_ifrs_recycled_objects_table.php
+++ b/database/migrations/2020_01_10_213405_create_ifrs_recycled_objects_table.php
@@ -14,15 +14,37 @@ use Illuminate\Support\Facades\Schema;
 class CreateIfrsRecycledObjectsTable extends Migration
 {
     /**
+     * Resolve the users table name from the configured User model.
+     *
+     * Handles both the string format ('App\Models\User') and the legacy
+     * array format ([7 => App\User::class, 8 => App\Models\User::class]).
+     *
+     * @return string
+     */
+    private function getUsersTable()
+    {
+        $userModel = config('ifrs.user_model');
+
+        if (is_array($userModel)) {
+            $major = (int) App::version();
+            $userModel = $userModel[$major] ?? end($userModel);
+        }
+
+        if (is_string($userModel) && class_exists($userModel)) {
+            return (new $userModel())->getTable();
+        }
+
+        return 'users';
+    }
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-
-        $userModel = config('ifrs.user_model');
-        $usersTable = (new $userModel())->getTable();
+        $usersTable = $this->getUsersTable();
 
         Schema::create(
             config('ifrs.table_prefix').'recycled_objects',


### PR DESCRIPTION
## Summary

- Migrations hardcode the users table name as `config('ifrs.table_prefix') . 'users'`, but the configured User model (e.g. `App\Models\User`) uses the `users` table via Eloquent's `getTable()`. When `table_prefix` is set (e.g. `'ifrs_'`, which is the shipped default), the migration targets `ifrs_users` while the model operates on `users` — a mismatch that breaks `entity_id` association and foreign key constraints.
- Fixed by resolving the table name from the configured `ifrs.user_model` via a `getUsersTable()` helper, in both `2014_10_12_000000_ifrs_create_or_update_users_table.php` and `2020_01_10_213405_create_ifrs_recycled_objects_table.php`.

## Steps to Reproduce

1. Install the package in a fresh Laravel 8+ app.
2. Ensure `config/ifrs.php` has `'table_prefix' => 'ifrs_'` (the shipped default).
3. Run `php artisan migrate`.
4. Observe that an `ifrs_users` table is created/modified, while `App\Models\User` reads/writes to the `users` table.
5. Any operation requiring `entity_id` on the User model (e.g. creating an Entity) fails because the column was never added to the correct `users` table.
6. The `recycled_objects` foreign key `user_id` references `ifrs_users`, causing foreign key constraint errors.

## The Fix

Added a `getUsersTable()` helper to each migration that resolves the table name from the configured User model:

```php
private function getUsersTable()
{
    $userModel = config('ifrs.user_model');

    if (is_array($userModel)) {
        $major = (int) App::version();
        $userModel = $userModel[$major] ?? end($userModel);
    }

    if (is_string($userModel) && class_exists($userModel)) {
        return (new $userModel())->getTable();
    }

    return 'users';
}
```

Handles both the current string format (`'App\Models\User'`) and the legacy array format (`[7 => App\User::class, 8 => App\Models\User::class]`), with a safe fallback to `'users'`.

## Backward Compatibility

| Scenario | Before | After |
|---|---|---|
| `table_prefix => ''` | `users` | `users` (no change) |
| `table_prefix => 'ifrs_'` + standard User model | `ifrs_users` (wrong) | `users` (correct) |
| Custom User model with custom `$table` | `ifrs_users` (wrong) | Model's actual table (correct) |
| Legacy array config format | N/A | Resolved by Laravel version |
| Config not published | Crash | Falls back to `'users'` |

- No new config options introduced
- Other IFRS tables (`entities`, `accounts`, etc.) continue using `table_prefix` as before

## Files Changed

- `database/migrations/2014_10_12_000000_ifrs_create_or_update_users_table.php` — all 6 references to the users table in `up()` and `down()`
- `database/migrations/2020_01_10_213405_create_ifrs_recycled_objects_table.php` — `getColumnType` and foreign key reference

## Test Plan

- [ ] Fresh install with `table_prefix => 'ifrs_'` - migration adds columns to `users`, not `ifrs_users`
- [ ] Fresh install with `table_prefix => ''` - behavior unchanged
- [ ] Custom User model with custom `$table` - migration targets the correct table
- [ ] `recycled_objects` foreign key references the correct users table
- [ ] Rollback (`php artisan migrate:rollback`) works correctly
- [ ] Legacy array config format resolves correctly
