### PR TITLE
Release: set 6.0.0 changelog date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.0.0 - 2026-06-29
+## 6.0.0 - 2026-07-01
 
 - Add Laravel 13 Compatibility
 - **BREAKING:** Raise minimum PHP requirement to 8.2 (PHP 8.1 reached end of life)


### PR DESCRIPTION
Sets the `6.0.0` CHANGELOG heading date to the actual release date (`2026-07-01`) ahead of tagging `v6.0.0`.

Docs-only change; no code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)